### PR TITLE
clusterctl : register ibmcloud and fix machine template issue

### DIFF
--- a/cmd/clusterctl/configuration/ibmcloud/machines.yaml.template
+++ b/cmd/clusterctl/configuration/ibmcloud/machines.yaml.template
@@ -1,3 +1,5 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineList
 items:
 - apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/apis"
 	"sigs.k8s.io/cluster-api-provider-ibmcloud/pkg/cloud/ibmcloud/actuators/cluster"
 	clusterapis "sigs.k8s.io/cluster-api/pkg/apis"
-	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 	capicluster "sigs.k8s.io/cluster-api/pkg/controller/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -62,9 +61,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
-	// Register our cluster deployer (the interface is in clusterctl and we define the Deployer interface on the actuator)
-	common.RegisterClusterProvisioner("ibmcloud", clusterActuator)
 
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		panic(err)

--- a/pkg/cloud/ibmcloud/deployer.go
+++ b/pkg/cloud/ibmcloud/deployer.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ibmcloud
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	clustercommon "sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/cluster-api/pkg/util"
+)
+
+const ProviderName = "ibmcloud"
+const (
+	IBMCloudIPAnnotationKey = "ibmcloud-ip-address"
+	IBMCloudIdAnnotationKey = "ibmcloud-resourceId"
+)
+
+func init() {
+	clustercommon.RegisterClusterProvisioner(ProviderName, NewDeploymentClient())
+}
+
+type DeploymentClient struct{}
+
+func NewDeploymentClient() *DeploymentClient {
+	return &DeploymentClient{}
+}
+
+func (d *DeploymentClient) GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
+	if machine.ObjectMeta.Annotations != nil {
+		if ip, ok := machine.ObjectMeta.Annotations[IBMCloudIPAnnotationKey]; ok {
+			log.Printf("Returning IP from machine annotation %s", ip)
+			return ip, nil
+		}
+	}
+
+	return "", errors.New("could not get IP")
+}
+
+// GetKubeConfig gets a kubeconfig from the master.
+func (d *DeploymentClient) GetKubeConfig(cluster *clusterv1.Cluster, master *clusterv1.Machine) (string, error) {
+	ip, err := d.GetIP(cluster, master)
+	if err != nil {
+		return "", err
+	}
+
+	homeDir, ok := os.LookupEnv("HOME")
+	if !ok {
+		return "", fmt.Errorf("unable to use HOME environment variable to find SSH key: %v", err)
+	}
+
+	// FIXME: use ssh user defined in machine spec name later
+	sshUserName := "ubuntu"
+	// FIXME: use other predefined ssh keyname or make this global definition
+	privateKey := "cluster-api-provider-ibmcloud"
+
+	result := strings.TrimSpace(util.ExecCommand(
+		"ssh", "-i", homeDir+"/.ssh/"+privateKey,
+		"-o", "StrictHostKeyChecking no",
+		"-o", "UserKnownHostsFile /dev/null",
+		"-o", "BatchMode=yes",
+		fmt.Sprintf("%s@%s", sshUserName, ip),
+		"echo STARTFILE; sudo cat /etc/kubernetes/admin.conf"))
+	parts := strings.Split(result, "STARTFILE")
+	if len(parts) != 2 {
+		return "", nil
+	}
+	return strings.TrimSpace(parts[1]), nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is part of #43 

`provider-component.yaml` is better to have before following up `clusterctl` fix.
