### PR TITLE
IBM specific ssh key name and clean generate.sh

### DIFF
--- a/cmd/clusterctl/example/ibmcloud/generate-yaml.sh
+++ b/cmd/clusterctl/example/ibmcloud/generate-yaml.sh
@@ -38,7 +38,7 @@ if [[ -n "$1" ]] && [[ $1 != -* ]] && [[ $1 != --* ]];then
   CLOUDS_PATH="$1"
 else
   echo "Error: No clouds.yaml provided"
-  echo "You must provide a valid clouds.yaml script to genereate a cloud.conf"
+  echo "You must provide a valid clouds.yaml"
   echo ""
   print_help
   exit 1
@@ -70,21 +70,6 @@ if test -z "$PROVIDER_OS"; then
   exit 1
 fi
 
-if ! hash yq 2>/dev/null; then
-  echo "'yq' is not available, please install it. (https://github.com/mikefarah/yq)"
-  echo ""
-  print_help
-  exit 1
-fi
-
-yq_type=$(file $(which yq))
-if [[ $yq_type == *"Python script"* ]]; then
-  echo "Wrong version of 'yq' installed, please install the one from https://github.com/mikefarah/yq"
-  echo ""
-  print_help
-  exit 1
-fi
-
 if [ -e out/provider-components.yaml ] && [ "$OVERWRITE" != "1" ]; then
   echo "Can't overwrite provider-components.yaml without user permission. Either run the script again"
   echo "with -f or --force-overwrite, or delete the file in the out/ directory."
@@ -96,7 +81,6 @@ fi
 
 # Define global variables
 PWD=$(cd `dirname $0`; pwd)
-TEMPLATES_PATH=${TEMPLATES_PATH:-$PWD/$SUPPORTED_PROVIDER_OS}
 CONFIG_DIR=$PWD/provider-component/clouds-secrets/configs
 OVERWRITE=${OVERWRITE:-0}
 CLOUDS_PATH=${CLOUDS_PATH:-""}
@@ -113,16 +97,17 @@ if [ ! -f ${CLOUD_SSH_HOME}${CLOUD_SSH_PRIVATE_FILE} ]; then
   ssh-keygen -t rsa -f ${CLOUD_SSH_HOME}${CLOUD_SSH_PRIVATE_FILE}  -N ""
 fi
 
-# Set up the output dir if it does not yet exist
-mkdir -p $PWD/out
-cp -n $PWD/cluster.yaml.template $PWD/out/cluster.yaml
-cp -n $PWD/machines.yaml.template $PWD/out/machines.yaml
-
+# Prepare dependecies for kustomize
 mkdir -p $CONFIG_DIR
 cat $PWD/$CLOUDS_PATH > $CONFIG_DIR/clouds.yaml
 
 cat "$MASTER_USER_DATA" > $USERDATA/$PROVIDER_OS/master-user-data.sh
 cat "$WORKER_USER_DATA" > $USERDATA/$PROVIDER_OS/worker-user-data.sh
+
+# Set up the output dir if it does not yet exist
+mkdir -p $PWD/out
+cp -n $PWD/cluster.yaml.template $PWD/out/cluster.yaml
+cp -n $PWD/machines.yaml.template $PWD/out/machines.yaml
 
 # Build provider-components.yaml with kustomize
 kustomize build ../../../../config -o out/provider-components.yaml

--- a/cmd/clusterctl/example/ibmcloud/generate-yaml.sh
+++ b/cmd/clusterctl/example/ibmcloud/generate-yaml.sh
@@ -104,6 +104,15 @@ USERDATA=$PWD/provider-component/user-data
 MASTER_USER_DATA=$USERDATA/$PROVIDER_OS/templates/master-user-data.sh
 WORKER_USER_DATA=$USERDATA/$PROVIDER_OS/templates/worker-user-data.sh
 
+CLOUD_SSH_PRIVATE_FILE=id_ibmcloud
+CLOUD_SSH_HOME=${HOME}/.ssh/
+# Create ssh key to access IBM Cloud machines on demand
+if [ ! -f ${CLOUD_SSH_HOME}${CLOUD_SSH_PRIVATE_FILE} ]; then
+  echo "Generating SSH key files for IBM cloud machine access."
+  # This is needed because GetKubeConfig assumes the key in the home .ssh dir.
+  ssh-keygen -t rsa -f ${CLOUD_SSH_HOME}${CLOUD_SSH_PRIVATE_FILE}  -N ""
+fi
+
 # Set up the output dir if it does not yet exist
 mkdir -p $PWD/out
 cp -n $PWD/cluster.yaml.template $PWD/out/cluster.yaml

--- a/pkg/cloud/ibmcloud/deployer.go
+++ b/pkg/cloud/ibmcloud/deployer.go
@@ -75,8 +75,7 @@ func (d *DeploymentClient) GetKubeConfig(cluster *clusterv1.Cluster, master *clu
 	}
 	sshUserName := providerSpec.SshUserName
 
-	// TODO: generate IBM Cloud specific keys
-	privateKey := "id_rsa"
+	privateKey := "id_ibmcloud"
 
 	result := strings.TrimSpace(util.ExecCommand(
 		"ssh", "-i", homeDir+"/.ssh/"+privateKey,


### PR DESCRIPTION
 - IBM specific ssh key name
The key is used to access IBM Cloud VM instances with `ssh -i path-to-ssh-key`. The key is generated on demands

- clean generate.sh
It does not need yq now.
It does not use TEMPLATES_PATH
Preparing dependecies should be in front of kustomizing logically.
