### PR TITLE
return error for not found case makes checking existence fail

### DIFF
--- a/pkg/cloud/ibmcloud/actuators/machine/actuator.go
+++ b/pkg/cloud/ibmcloud/actuators/machine/actuator.go
@@ -129,6 +129,10 @@ func (ic *IbmCloudClient) Create(ctx context.Context, cluster *clusterv1.Cluster
 		return err
 	}
 
+	if guest == nil {
+		return fmt.Errorf("Guest host does not found")
+	}
+
 	return ic.updateAnnotation(machine, strconv.Itoa(*guest.Id))
 }
 
@@ -167,11 +171,12 @@ func (ic *IbmCloudClient) Update(ctx context.Context, cluster *clusterv1.Cluster
 
 // Exists test for the existance of a machine and is invoked by the Machine Controller
 func (ic *IbmCloudClient) Exists(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (bool, error) {
-	_, err := ic.getGuest(machine)
+	guest, err := ic.getGuest(machine)
 	if err != nil {
 		return false, err
 	}
-	return true, nil
+
+	return guest != nil, nil
 }
 
 func (ic *IbmCloudClient) getGuest(machine *clusterv1.Machine) (*datatypes.Virtual_Guest, error) {

--- a/pkg/cloud/ibmcloud/clients/machines.go
+++ b/pkg/cloud/ibmcloud/clients/machines.go
@@ -188,7 +188,7 @@ func (gs *GuestService) GetGuest(name string) (*datatypes.Virtual_Guest, error) 
 			return &guest, nil
 		}
 	}
-	return nil, fmt.Errorf("Virtual guest %q does not found", name)
+	return nil, nil
 }
 
 // TODO: directly get ID of ssh key instead of list and search


### PR DESCRIPTION
Machine actuator API of `Exists` return `true` or `false` with no error for common check. It is error if other condition happens in API implementation.

Previously, I try to use not found case as an error. It is not convenient for this case and make API logic wrong

Fixes #91